### PR TITLE
Add base dashboard for PAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,23 @@ Ask Pam through the chat interface, or contact Carl directly.
 All tasks, feedback loops, and system improvements are documented and traceable.
 
 ---
+
+## Development Setup
+
+This repository includes a minimal FastAPI backend and static HTML dashboard.
+
+### Files
+- `main.py` – FastAPI application providing API routes for inventory, tasks, and chat history.
+- `index.html` – Simple dashboard interface using Bootstrap and JavaScript fetch calls.
+- `inventory.json` / `tasks.json` / `chat.json` – Mock data files persisted locally.
+
+### Running the Server
+1. Install dependencies:
+   ```bash
+   pip install fastapi uvicorn pydantic
+   ```
+2. Start the server:
+   ```bash
+   uvicorn main:app --reload
+   ```
+3. Open `index.html` in a browser and interact with the dashboard.

--- a/chat.json
+++ b/chat.json
@@ -1,0 +1,3 @@
+[
+  {"sender": "Pam", "message": "Welcome to the dashboard."}
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>P.A.M. Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+<h1 class="mb-4">P.A.M. Dashboard</h1>
+<div class="row">
+  <div class="col-md-6">
+    <h3>Chat</h3>
+    <div id="chat-window" class="border p-2 mb-2" style="height: 200px; overflow-y: scroll;"></div>
+    <div class="input-group">
+      <input id="chat-input" class="form-control" placeholder="Type a message" />
+      <button id="send-btn" class="btn btn-primary">Send</button>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <h3>Current Inventory</h3>
+    <table class="table" id="inventory-table">
+      <thead>
+        <tr><th>Name</th><th>Location</th><th>Qty</th><th>PAR</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+<div class="row mt-4">
+  <div class="col-md-6">
+    <h3>Tasks</h3>
+    <ul id="tasks-list" class="list-group"></ul>
+  </div>
+  <div class="col-md-6">
+    <h3>Actions</h3>
+    <button class="btn btn-secondary" onclick="alert('Not implemented')">Generate PO</button>
+  </div>
+</div>
+<script>
+const api = '';
+
+async function loadInventory() {
+  const res = await fetch(api + '/inventory');
+  const data = await res.json();
+  const tbody = document.querySelector('#inventory-table tbody');
+  tbody.innerHTML = '';
+  data.forEach(item => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${item.name}</td><td>${item.location}</td><td>${item.quantity}</td><td>${item.par_level}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+async function loadTasks() {
+  const res = await fetch(api + '/tasks');
+  const data = await res.json();
+  const list = document.getElementById('tasks-list');
+  list.innerHTML = '';
+  data.forEach(task => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item';
+    li.textContent = `${task.description} (${task.status})`;
+    list.appendChild(li);
+  });
+}
+
+async function loadChat() {
+  const res = await fetch(api + '/chat');
+  const data = await res.json();
+  const win = document.getElementById('chat-window');
+  win.innerHTML = '';
+  data.forEach(msg => {
+    const div = document.createElement('div');
+    div.textContent = `${msg.sender}: ${msg.message}`;
+    win.appendChild(div);
+  });
+  win.scrollTop = win.scrollHeight;
+}
+
+async function sendMessage() {
+  const input = document.getElementById('chat-input');
+  const msg = input.value.trim();
+  if (!msg) return;
+  await fetch(api + '/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sender: 'user', message: msg })
+  });
+  input.value = '';
+  await loadChat();
+}
+
+document.getElementById('send-btn').addEventListener('click', sendMessage);
+
+window.addEventListener('load', () => {
+  loadInventory();
+  loadTasks();
+  loadChat();
+});
+</script>
+</body>
+</html>

--- a/inventory.json
+++ b/inventory.json
@@ -1,0 +1,4 @@
+[
+  {"name": "Gloves", "location": "Warehouse", "quantity": 100, "par_level": 50},
+  {"name": "Masks", "location": "2nd Floor", "quantity": 200, "par_level": 100}
+]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,110 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from typing import List
+import json
+from pathlib import Path
+from datetime import datetime
+
+DATA_DIR = Path(__file__).resolve().parent
+INVENTORY_FILE = DATA_DIR / "inventory.json"
+TASKS_FILE = DATA_DIR / "tasks.json"
+CHAT_FILE = DATA_DIR / "chat.json"
+
+app = FastAPI(title="P.A.M. Dashboard API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Utility functions ----------------------------------------------------------
+
+def load_json(path: Path, default):
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return default
+
+
+def save_json(path: Path, data):
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def log_update(entry: dict):
+    entry["timestamp"] = datetime.utcnow().isoformat()
+
+# Data models ---------------------------------------------------------------
+
+class InventoryItem(BaseModel):
+    name: str
+    location: str
+    quantity: int
+    par_level: int
+
+class Task(BaseModel):
+    id: int
+    description: str
+    assigned_to: str
+    status: str = "open"
+    notes: str = ""
+
+class ChatMessage(BaseModel):
+    sender: str
+    message: str
+
+# Routes --------------------------------------------------------------------
+
+@app.get("/inventory", response_model=List[InventoryItem])
+def get_inventory():
+    return load_json(INVENTORY_FILE, [])
+
+@app.post("/inventory", response_model=InventoryItem)
+def update_inventory(item: InventoryItem):
+    items = load_json(INVENTORY_FILE, [])
+    for idx, existing in enumerate(items):
+        if existing["name"] == item.name and existing["location"] == item.location:
+            items[idx] = item.dict()
+            log_update(items[idx])
+            save_json(INVENTORY_FILE, items)
+            return item
+    items.append(item.dict())
+    log_update(items[-1])
+    save_json(INVENTORY_FILE, items)
+    return item
+
+@app.get("/tasks", response_model=List[Task])
+def get_tasks():
+    return load_json(TASKS_FILE, [])
+
+@app.post("/tasks", response_model=Task)
+def add_or_update_task(task: Task):
+    tasks = load_json(TASKS_FILE, [])
+    for idx, existing in enumerate(tasks):
+        if existing["id"] == task.id:
+            tasks[idx] = task.dict()
+            log_update(tasks[idx])
+            save_json(TASKS_FILE, tasks)
+            return task
+    tasks.append(task.dict())
+    log_update(tasks[-1])
+    save_json(TASKS_FILE, tasks)
+    return task
+
+@app.get("/chat", response_model=List[ChatMessage])
+def get_chat():
+    return load_json(CHAT_FILE, [])
+
+@app.post("/chat", response_model=ChatMessage)
+def post_chat(msg: ChatMessage):
+    history = load_json(CHAT_FILE, [])
+    entry = msg.dict()
+    log_update(entry)
+    history.append(entry)
+    save_json(CHAT_FILE, history)
+    return msg
+

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,4 @@
+[
+  {"id": 1, "description": "Organize CK Supply Room", "assigned_to": "Thomas", "status": "open", "notes": ""},
+  {"id": 2, "description": "Build barcode DB", "assigned_to": "Pam", "status": "open", "notes": ""}
+]


### PR DESCRIPTION
## Summary
- implement FastAPI backend with routes for inventory, tasks, and chat
- add Bootstrap-based dashboard (index.html) with chat, inventory, and tasks panels
- include mock inventory, tasks, and chat data
- update README with development setup instructions

## Testing
- `pip install fastapi uvicorn pydantic --quiet`
- `python -m py_compile main.py`
- `uvicorn main:app --reload --port 8000 &` *(tested inventory endpoint)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687733fcafdc832bb7af519ee99f7e6c